### PR TITLE
Fixes not found accounts and UTC time parsing

### DIFF
--- a/src/app/profile/profile/components/posts/resources/filters.js
+++ b/src/app/profile/profile/components/posts/resources/filters.js
@@ -33,6 +33,6 @@ export default {
    * @return {string}
    */
   humanDate (value) {
-    return moment(value).fromNow()
+    return moment.utc(value).fromNow()
   }
 }

--- a/src/app/profile/profile/profile.pug
+++ b/src/app/profile/profile/profile.pug
@@ -1,6 +1,14 @@
 // profile page wrapper.
-div.row.row-eq-height.profile-content(v-if="!loading")
-  div.col
+div.row.row-eq-height.profile-content
+  div.col(v-if="error === true")
+    div.not-found-message
+      em.icon-exclamation
+      span
+        | Sorry, the account you're looking for could not be found.
+        br
+        a(href="/") Click here
+        | , to try again
+  div.col(v-if="error === false && !loading")
     // first line row wrapper
     div.row.row-eq-height
       // profile information / user box.

--- a/src/app/profile/profile/profile.scss
+++ b/src/app/profile/profile/profile.scss
@@ -6,6 +6,21 @@
     line-height: 1.8em;
   }
 
+  .not-found-message {
+    font-size: 20px;
+    font-weight: 500;
+    letter-spacing: 0.025em;
+    text-align: center;
+    //background-color: $gray-200;
+    //color: $gray-900;
+    em {
+      font-weight: 700;
+      display: block;
+      padding: 0;
+      font-size: 40px;
+    }
+  }
+
   em {
     margin-right: 15px;
     font-weight: 700;

--- a/src/app/profile/profile/resources/data.js
+++ b/src/app/profile/profile/resources/data.js
@@ -1,0 +1,10 @@
+/**
+ * Data resource.
+ *
+ * @return {{error: boolean}}
+ */
+export default function () {
+  return {
+    error: false
+  }
+}

--- a/src/app/profile/profile/resources/index.js
+++ b/src/app/profile/profile/resources/index.js
@@ -1,5 +1,6 @@
 import components from './components'
 import computed from './computed'
+import data from './data'
 import filters from './filters'
 import methods from './methods'
 import mounted from './mounted'
@@ -7,6 +8,7 @@ import mounted from './mounted'
 export default {
   components,
   computed,
+  data,
   filters,
   methods,
   mounted

--- a/src/app/profile/profile/resources/mounted.js
+++ b/src/app/profile/profile/resources/mounted.js
@@ -5,5 +5,7 @@ export default function () {
   const username = get(this.$route.params, 'username')
 
   // call the user loading action.
-  this.loadUserByUsername(username)
+  this.loadUserByUsername(username).catch(() => {
+    this.error = true
+  })
 }


### PR DESCRIPTION
This PR introduces two fixes:

- When the account cannot be found, an error message with a link to try again on the home page is displayed.
- Payout countdown time is correctly parsing UTC times, preventing wrong estimates.